### PR TITLE
Add functionality for short options

### DIFF
--- a/magicli.py
+++ b/magicli.py
@@ -1,4 +1,5 @@
 import inspect
+import re
 import sys
 
 
@@ -71,7 +72,16 @@ def get_kwargs(argv, function):
     kwargs = {}
 
     for key in iterator:
-        if key.startswith("--"):
+        if key.startswith("-"):
+            if not key.startswith("--") and len(key) == 2:
+                short_option = key[1]
+
+                long_option = re.findall(rf"(?:^|\n) *-{short_option},? +--([a-z]+)", function.__doc__ or "")
+                if not long_option:
+                    raise KeyError
+
+                key = "--" + long_option[0]
+
             value = None
             key = key[2:].replace("-", "_")
 

--- a/tests/test_get_kwargs.py
+++ b/tests/test_get_kwargs.py
@@ -94,7 +94,7 @@ def test_none():
 )
 def test_errors(prompt, error, function):
     with pytest.raises(error):
-        assert get_kwargs(prompt.split(), function)
+        get_kwargs(prompt.split(), function)
 
 
 def test_two_values_for_kwarg():

--- a/tests/test_get_kwargs.py
+++ b/tests/test_get_kwargs.py
@@ -22,9 +22,52 @@ def test_io(prompt, result, function):
     assert get_kwargs(prompt.split(), function) == result
 
 
+def test_short_option():
+    def f(aaa: str=""):
+        """-a, --aaa  Docstring."""
+        ...
+
+    prompt = "-a string".split()
+    assert get_kwargs(prompt, f) == {"aaa": "string"}
+
+
+def test_short_option_bool():
+    def f(aaa: bool=False):
+        """/
+        -a, --aaa  Docstring a.
+        -b, --bbb  Docstring b.
+        """
+        ...
+
+    assert get_kwargs(["-a"], f) == {"aaa": True}
+
+
+def test_short_options():
+    def f(aaa: str="", bbb: bool=False):
+        """/
+        -a, --aaa  Docstring a.
+        -b, --bbb  Docstring b.
+        """
+        ...
+
+    prompt = "-a string -b".split()
+    result = {
+        "aaa": "string",
+        "bbb": True,
+    }
+    assert get_kwargs(prompt, f) == result
+
+
+def test_short_option_failure():
+    def f(aaa: bool=False): ...
+
+    assert get_kwargs(["--aaa"], f) == {"aaa": True}
+    with pytest.raises(KeyError):
+        get_kwargs(["-a"], f)
+
+
 def test_int():
     def f(arg: int): ...
-
     assert get_kwargs(["1"], f) == {"arg": 1}
 
 

--- a/tests/test_magicli.py
+++ b/tests/test_magicli.py
@@ -72,13 +72,13 @@ def test_success(prompt, output, capsys):
 )
 def test_failure(prompt, output, capsys):
     with pytest.raises(SystemExit):
-        assert output == _cli(prompt, capsys)
+        output == _cli(prompt, capsys)
 
 
 def test_fail_on_arg_as_kwarg(capsys):
     assert _cli("say hello", capsys) == "hello world"
     with pytest.raises(SystemExit):
-        assert _cli("say hello magicli", capsys)
+        _cli("say hello magicli", capsys)
 
 
 def test_show_version(capsys):

--- a/tests/test_magicli.py
+++ b/tests/test_magicli.py
@@ -51,7 +51,7 @@ def _cli(prompt, capsys=None):
     [
         ("foo", foo.__name__ * 2),
         ("foo --help", foo.__doc__),
-        # ("foo bar", bar.__name__ * 2),
+        ("foo bar", bar.__name__ * 2),
         ("foo bar --help", bar.__doc__),
         ("foo custom-version --version", "Version: " + __version__),
         ("foo custom-help --help", "Help: " + custom_help.__name__),


### PR DESCRIPTION
This PR adds the functionality to use shot options (`-h`). These will be expanded if set in the docstring of the function. (i.e. `-h, --help`).