### PR TITLE
Switch build backend to setuptools with version from git tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ _*
 .pytest_cache
 .vscode
 .venv
+build
+*.egg-info

--- a/magicli.py
+++ b/magicli.py
@@ -2,7 +2,7 @@ import inspect
 import sys
 
 
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 
 
 def magicli(

--- a/magicli.py
+++ b/magicli.py
@@ -1,9 +1,11 @@
 import inspect
 import sys
+from importlib import metadata
 
-
-__version__ = "1.1.1"
-
+try:
+    __version__ = metadata.version("magicli")
+except metadata.PackageNotFoundError:
+    pass
 
 def magicli(
     frame_globals=inspect.currentframe().f_back.f_globals,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["flit_core >=3.2,<4"]
-build-backend = "flit_core.buildapi"
+requires = ["setuptools>=80", "setuptools-scm[simple]>=8"]
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "magicli"


### PR DESCRIPTION
This PR switches to setuptools as build backend with dynamic version information from the latest git tag.